### PR TITLE
convenience function and decorator for setting bootstrap widgets

### DIFF
--- a/bootstrap/widgets.py
+++ b/bootstrap/widgets.py
@@ -206,9 +206,10 @@ def auto_bootstrap_field_widget(field):
     }
     widget_class = type(field.widget)
     if widget_class in translation_map:
+        has_choices = hasattr(field.widget, 'choices')
         choices = getattr(field.widget, 'choices', None)
         field.widget = translation_map.get(widget_class)()
         # need to copy over choices since django pre-caches choices into widget when building form field
-        if choices:
+        if has_choices:
             field.widget.choices = choices
 


### PR DESCRIPTION
Just added this code for a project, and thought it might be useful in the main bootstrap lib. Basically this code adds a convenience function and a decorator that can be used to quickly set all of widgets of a form to use the bootstrap version. 

Either more manually via a call to the function:
``

```
 class MyForm(forms.ModelForm)
     class Meta:
        model = MyModel
        widgets = { 'my_custom_field': special_widgets.MySpecialWidget }
     def __init__(self, *args, **kwargs):
          super()
          auto_bootstrap_form_widgets(self)
```

Or by just adding a decorator around the form class

``

```
@bootstrap_form
class MyForm(forms.ModelForm)
```

   .....

Both the function and decorator can take optional kwargs. 

What do you think?
