### PR TITLE
838 508 compliance fixes to bootstrap field

### DIFF
--- a/bootstrap/templates/bootstrap/field.html
+++ b/bootstrap/templates/bootstrap/field.html
@@ -2,14 +2,12 @@
     {{ field }}
 {% else %}
     <div id="{{ field.auto_id }}-group" class="form-group field-{{ field_class }} widget-{{ widget_class }}{% if field.errors %} has-error{% endif %}{% if field.field.required %} required{% endif %}{% if extra_classes %} {{ extra_classes }}{% endif %}">
-        {% if show_label and not is_checkbox and not is_radioselect%}
-        <label for="{{ field.auto_id }}">{{ field.label }}</label>
-        {% elif is_radioselect %}
-        <label for="{{ field.auto_id }}" id="{{ field.auto_id }}-radiogroup">{{ field.label }}</label>
+        {% if show_label and not is_checkbox %}
+        <label for="{{ field.auto_id }}" id="{{ field.auto_id }}-label">{{ field.label }}</label>
         {% endif %}
         <div class="controls clearfix">
             {% if is_checkbox %}
-                <label class="checkbox-inline">{{ field }} {{ field.label }}</label>
+                <label class="checkbox-inline" id="{{ field.auto_id }}-label">{{ field }} {{ field.label }}</label>
             {% else %}
                 {{ field }}
             {% endif %}

--- a/bootstrap/templates/bootstrap/field.html
+++ b/bootstrap/templates/bootstrap/field.html
@@ -2,8 +2,10 @@
     {{ field }}
 {% else %}
     <div id="{{ field.auto_id }}-group" class="form-group field-{{ field_class }} widget-{{ widget_class }}{% if field.errors %} has-error{% endif %}{% if field.field.required %} required{% endif %}{% if extra_classes %} {{ extra_classes }}{% endif %}">
-        {% if show_label and not is_checkbox %}
+        {% if show_label and not is_checkbox and not is_radioselect%}
         <label for="{{ field.auto_id }}">{{ field.label }}</label>
+        {% elif is_radioselect %}
+        <label for="{{ field.auto_id }}" id="{{ field.auto_id }}-radiogroup">{{ field.label }}</label>
         {% endif %}
         <div class="controls clearfix">
             {% if is_checkbox %}

--- a/bootstrap/templatetags/bootstrap.py
+++ b/bootstrap/templatetags/bootstrap.py
@@ -90,7 +90,12 @@ def bootstrap_field(field, classes='', template=None, **kwargs):
     extra_classes = getattr(field.field, 'css_classes', [])
     if extra_classes:
         classes += ' ' + ' '.join(extra_classes)
-    # Need to shoehorn some ARIA attributes onto the widget based on information on the field.
+    # Need to shoehorn some ARIA attributes onto the widget based on information on the field
+    labelledby = set(field.field.widget.attrs.get('aria-labelledby', '').split())
+    if widget_class == 'radioselect':
+        labelledby.add('%s-radiogroup' % field.auto_id)
+    if labelledby:
+        field.field.widget.attrs['aria-labelledby'] = ' '.join(labelledby)
     describedby = set(field.field.widget.attrs.get('aria-describedby', '').split())
     if field.help_text:
         describedby.add('%s-help' % field.auto_id)
@@ -101,6 +106,7 @@ def bootstrap_field(field, classes='', template=None, **kwargs):
     params = {
         'field': field,
         'is_checkbox': isinstance(field.field.widget, forms.CheckboxInput),
+        'is_radioselect': isinstance(field.field.widget, forms.RadioSelect),
         'show_label': getattr(field.field.widget, 'show_label', True),
         'use_fieldset': getattr(field.field.widget, 'use_fieldset', False),
         'field_class': field_class,

--- a/bootstrap/templatetags/bootstrap.py
+++ b/bootstrap/templatetags/bootstrap.py
@@ -92,10 +92,8 @@ def bootstrap_field(field, classes='', template=None, **kwargs):
         classes += ' ' + ' '.join(extra_classes)
     # Need to shoehorn some ARIA attributes onto the widget based on information on the field
     labelledby = set(field.field.widget.attrs.get('aria-labelledby', '').split())
-    if widget_class == 'radioselect':
-        labelledby.add('%s-radiogroup' % field.auto_id)
-    if labelledby:
-        field.field.widget.attrs['aria-labelledby'] = ' '.join(labelledby)
+    labelledby.add('%s-label' % field.auto_id)
+    field.field.widget.attrs['aria-labelledby'] = ' '.join(labelledby)
     describedby = set(field.field.widget.attrs.get('aria-describedby', '').split())
     if field.help_text:
         describedby.add('%s-help' % field.auto_id)
@@ -106,7 +104,6 @@ def bootstrap_field(field, classes='', template=None, **kwargs):
     params = {
         'field': field,
         'is_checkbox': isinstance(field.field.widget, forms.CheckboxInput),
-        'is_radioselect': isinstance(field.field.widget, forms.RadioSelect),
         'show_label': getattr(field.field.widget, 'show_label', True),
         'use_fieldset': getattr(field.field.widget, 'use_fieldset', False),
         'field_class': field_class,

--- a/bootstrap/widgets.py
+++ b/bootstrap/widgets.py
@@ -65,7 +65,7 @@ class BootstrapWidget (object):
         attrs = super(BootstrapWidget, self).build_attrs(*args, **kwargs)
         if self.is_required and not isinstance(self, RadioSelect):
             attrs.update({'aria-required': 'true'})
-        if isinstance(self, RadioSelect):
+        if self.is_required and isinstance(self, RadioSelect):
             attrs.update({'required': 'required'})
         attrs.update(self.extra_attrs)
         new_class = '%s %s' % (attrs.get('class', ''), ' '.join(self.css_classes))

--- a/bootstrap/widgets.py
+++ b/bootstrap/widgets.py
@@ -63,8 +63,10 @@ class BootstrapWidget (object):
 
     def build_attrs(self, *args, **kwargs):
         attrs = super(BootstrapWidget, self).build_attrs(*args, **kwargs)
-        if self.is_required:
+        if self.is_required and not isinstance(self, RadioSelect):
             attrs.update({'aria-required': 'true'})
+        if isinstance(self, RadioSelect):
+            attrs.update({'required': 'required'})
         attrs.update(self.extra_attrs)
         new_class = '%s %s' % (attrs.get('class', ''), ' '.join(self.css_classes))
         attrs['class'] = new_class.strip()


### PR DESCRIPTION
Added aria-labelledby='field.auto_id' to radio select fields. 
Removed the 'help' string that was appended after the aria-describedby. 
Removed aria-required from radio selects since they're not allowed for radio selects.