### PR TITLE
form labels need not be <strong>

### DIFF
--- a/bootstrap/templates/bootstrap/field.html
+++ b/bootstrap/templates/bootstrap/field.html
@@ -3,7 +3,7 @@
 {% else %}
     <div id="{{ field.auto_id }}-group" class="mb-3 field-{{ field_class }} widget-{{ widget_class }}{% if is_checkbox %} form-check{% endif %}{% if field.field.required %} required{% endif %}{% if extra_classes %} {{ extra_classes }}{% endif %}">
         {% if show_label and not is_checkbox %}
-        <label class="form-label" for="{{ field.auto_id }}" id="{{ field.auto_id }}-label"><strong>{{ field.label }}</strong></label>
+        <label class="form-label" for="{{ field.auto_id }}" id="{{ field.auto_id }}-label">{{ field.label }}</label>
         {% endif %}
         <div class="controls clearfix">
             {% if use_fieldset %}


### PR DESCRIPTION
I don't know why labels are wrapped in a strong tag. There is nothing in bootstrap about that.